### PR TITLE
refactor(heatmaps): extract HeatmapModal, HeatmapImage, and download lib fn

### DIFF
--- a/src/components/HeatmapImage.tsx
+++ b/src/components/HeatmapImage.tsx
@@ -1,0 +1,39 @@
+import { Download } from "lucide-react";
+import downloadImage from "@/lib/downloadImage";
+import { useState } from "react";
+
+const HeatmapImage: React.FC<{
+  src: string;
+  alt: string;
+  onClick: () => void;
+}> = ({ src, alt, onClick }) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  return (
+    <div
+      className="relative"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <img
+        src={src}
+        alt={alt}
+        className="w-full rounded-md shadow-sm cursor-pointer transition-transform hover:scale-105"
+        onClick={onClick}
+      />
+      {isHovered && (
+        <div
+          className="absolute top-2 right-2 p-2 bg-gray-800 bg-opacity-50 rounded-full cursor-pointer transition-opacity hover:bg-opacity-75"
+          onClick={(e) => {
+            e.stopPropagation();
+            downloadImage(src, `${alt.replace(/\s+/g, "_")}.png`);
+          }}
+        >
+          <Download className="h-5 w-5 text-white" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HeatmapImage;

--- a/src/components/HeatmapModal.tsx
+++ b/src/components/HeatmapModal.tsx
@@ -1,0 +1,44 @@
+import React, { useCallback } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Download } from "lucide-react";
+import downloadImage from "@/lib/downloadImage";
+
+type HeatmapModalProps = {
+  src: string;
+  alt: string;
+  open: boolean;
+  onClose: () => void;
+};
+
+export function HeatmapModal({ src, alt, open, onClose }: HeatmapModalProps) {
+  const handleDownload = useCallback(() => {
+    const filename = `${alt.replace(/\s+/g, "_")}.png`;
+    downloadImage(src, filename);
+  }, [alt, src]);
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-6xl" aria-describedby="heatmap-modal">
+        <DialogHeader>
+          <DialogTitle>{alt}</DialogTitle>
+        </DialogHeader>
+        <div className="relative">
+          <img src={src} alt={alt} className="w-full h-auto" />
+          <div
+            className="absolute -top-[3rem] right-3 p-2 bg-gray-800 bg-opacity-50 rounded-full cursor-pointer transition-opacity hover:bg-opacity-75"
+            onClick={handleDownload}
+          >
+            <Download className="h-6 w-6 text-white" />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default HeatmapModal;

--- a/src/components/Heatmaps.tsx
+++ b/src/components/Heatmaps.tsx
@@ -10,21 +10,17 @@ import {
   MeasurementTestType,
   testTypes,
 } from "@/lib/types";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+
 import { Checkbox } from "@/components/ui/checkbox";
 import { Switch } from "@/components/ui/switch";
-import { Download } from "lucide-react";
 import { HeatmapSlider } from "./Slider";
 
 import { IperfTestProperty } from "@/lib/types";
 import { metricFormatter } from "@/lib/utils";
 import { getLogger } from "@/lib/logger";
 import createHeatmapWebGLRenderer from "../app/webGL/renderers/mainRenderer";
+import HeatmapImage from "./HeatmapImage";
+import HeatmapModal from "./HeatmapModal";
 
 const logger = getLogger("Heatmaps");
 
@@ -421,49 +417,6 @@ export function Heatmaps() {
     setSelectedHeatmap(null);
   };
 
-  const downloadImage = (imageUrl: string, fileName: string) => {
-    const link = document.createElement("a");
-    link.href = imageUrl;
-    link.download = fileName;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  };
-
-  const HeatmapImage: React.FC<{
-    src: string;
-    alt: string;
-    onClick: () => void;
-  }> = ({ src, alt, onClick }) => {
-    const [isHovered, setIsHovered] = useState(false);
-
-    return (
-      <div
-        className="relative"
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      >
-        <img
-          src={src}
-          alt={alt}
-          className="w-full rounded-md shadow-sm cursor-pointer transition-transform hover:scale-105"
-          onClick={onClick}
-        />
-        {isHovered && (
-          <div
-            className="absolute top-2 right-2 p-2 bg-gray-800 bg-opacity-50 rounded-full cursor-pointer transition-opacity hover:bg-opacity-75"
-            onClick={(e) => {
-              e.stopPropagation();
-              downloadImage(src, `${alt.replace(/\s+/g, "_")}.png`);
-            }}
-          >
-            <Download className="h-5 w-5 text-white" />
-          </div>
-        )}
-      </div>
-    );
-  };
-
   useEffect(() => {
     if (settings.dimensions.width > 0 && settings.dimensions.height > 0) {
       generateAllHeatmaps();
@@ -618,33 +571,12 @@ export function Heatmaps() {
         ))}
       </div>
 
-      <Dialog open={selectedHeatmap !== null} onOpenChange={closeHeatmapModal}>
-        <DialogContent className="max-w-6xl" aria-describedby="heatmap-modal">
-          <DialogHeader>
-            <DialogTitle>{selectedHeatmap?.alt}</DialogTitle>
-          </DialogHeader>
-          {selectedHeatmap && (
-            <div className="relative">
-              <img
-                src={selectedHeatmap.src}
-                alt={selectedHeatmap.alt}
-                className="w-full h-auto"
-              />
-              <div
-                className="absolute -top-[3rem] right-3 p-2 bg-gray-800 bg-opacity-50 rounded-full cursor-pointer transition-opacity hover:bg-opacity-75"
-                onClick={() =>
-                  downloadImage(
-                    selectedHeatmap.src,
-                    `${selectedHeatmap.alt.replace(/\s+/g, "_")}.png`,
-                  )
-                }
-              >
-                <Download className="h-6 w-6 text-white" />
-              </div>
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
+      <HeatmapModal
+        src={selectedHeatmap?.src ?? ""}
+        alt={selectedHeatmap?.alt ?? ""}
+        open={selectedHeatmap !== null}
+        onClose={closeHeatmapModal}
+      />
     </div>
   );
 }

--- a/src/lib/downloadImage.ts
+++ b/src/lib/downloadImage.ts
@@ -1,0 +1,10 @@
+const downloadImage = (imageUrl: string, fileName: string) => {
+  const link = document.createElement("a");
+  link.href = imageUrl;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};
+
+export default downloadImage;


### PR DESCRIPTION
### Summary
Refactored `Heatmaps.tsx` to split out modal and image UI into standalone components, and moved download logic into a shared utility. No functional changes, small cleanup and better separation of concerns. :) (more in another PR, keeping this one nice & small)

Helps address [#39](https://github.com/[your-repo]/issues/39) – *Code Organization*

---

### Changes
-  **Moved Out** `HeatmapModal.tsx`  -  Encapsulates modal UI and image download behavior
- **Moved Out** `HeatmapImage.tsx`  -  Handles heatmap thumbnail with hover-based download action
- **Moved Out** `lib/downloadImage.ts`  -  Shared utility for triggering image downloads
---

### Notes
- Functionality / API remains identical to original implementation

### Screenshot
<img width="1589" height="1170" alt="image" src="https://github.com/user-attachments/assets/94c98066-1456-4604-bc5f-39df37ac210f" />
