### PR TITLE
Enable debug logging for command execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ _This section follows the precepts of [Keep a Changelog](https://keepachangelog.
 
 ---
 
+## Version 0.3.6 - 2026-01-04
+
+* Enable debug logging for command execution in `execAsync()`.
+  Run with `LOG_LEVEL=2` to see commands and their output.
+  Helps diagnose issues like #65.
+
+---
+
 ## Version 0.3.5 - 2025-10-01
 
 * Updated screen shot on README.md to use a heat map drawn on

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wifi-heatmapper",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wifi-heatmapper",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "@radix-ui/colors": "^3.0.0",
         "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wifi-heatmapper",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/lib/server-utils.ts
+++ b/src/lib/server-utils.ts
@@ -1,7 +1,7 @@
 "use server";
 import { exec, ExecOptions, spawn } from "child_process";
-// import { getLogger } from "./logger";
-// const logger = getLogger("server-utils");
+import { getLogger } from "./logger";
+const logger = getLogger("server-utils");
 
 /**
  * exexAsync - asynchronously run the command, return { stdout, stderr }
@@ -29,13 +29,13 @@ export const execAsync = async (
   const options: ExecOptions = { shell: true }; // Node.js finds the right binary for the OS
 
   return new Promise((resolve, reject) => {
-    // logger.info("Executing command:", command);
+    logger.debug("Executing command:", command);
     exec(command, options, (error, stdout, stderr) => {
       if (error) {
-        // logger.info(`execAsync(${command} rejects with "${error}")`);
+        logger.debug(`execAsync(${command}) rejects with "${error}"`);
         reject(error);
       } else {
-        // logger.info(`Command result: ${JSON.stringify(stdout)}`);
+        logger.debug(`Command result: ${JSON.stringify(stdout)}`);
         resolve({ stdout: stdout.trimEnd(), stderr: stderr.trimEnd() });
       }
     });


### PR DESCRIPTION
Fixes debugging for issues like #65 where command output isn't visible.

With `LOG_LEVEL=2`, users can now see what commands are executed and their output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)