### PR TITLE
Fix band units displaying MHz instead of GHz

### DIFF
--- a/__tests__/iperfRunner.test.ts
+++ b/__tests__/iperfRunner.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { extractIperfResults } from "../src/lib/utils";
-import {
-  buildIperfCommand,
-  defaultIperfCommands,
-} from "../src/lib/iperfUtils";
+import { buildIperfCommand, defaultIperfCommands } from "../src/lib/iperfUtils";
 import fs from "fs";
 import path from "path";
 

--- a/src/components/PointsTable.tsx
+++ b/src/components/PointsTable.tsx
@@ -249,7 +249,7 @@ const SurveyPointsTable: React.FC<SurveyPointsTableProps> = ({
         signalQuality:
           point.wifiData.signalStrength ||
           rssiToPercentage(point.wifiData.rssi),
-        band: `${point.wifiData.band} Mhz`,
+        band: `${point.wifiData.band} GHz`,
         timestamp: new Date(point.timestamp).toLocaleString(),
       };
     });


### PR DESCRIPTION
## Summary
- Fixed the Survey Points view Band column showing incorrect units (MHz → GHz)
- Values like "2.4 MHz" and "5 MHz" now correctly display as "2.4 GHz" and "5 GHz"

Fixes #76

## Test plan
- [ ] Place a test point on a heatmap
- [ ] Navigate to Survey Points view
- [ ] Verify the Band column shows "GHz" instead of "MHz"

🤖 Generated with [Claude Code](https://claude.com/claude-code)