### PR TITLE
Win32 Wlan API via koffi; map real RSSI value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 _This section follows the precepts of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) so that future readers can understand the state and evolution of the project._
 
+## Version 0.5.0 - 2026-08-21
+
+* Windows OS now uses Win32 Wlan API calls via koffi to get interfaces and measurements. 
+* Include acutual RSSI (in dBm) in Floor Plan and Heat Maps (with a toggle to switch to signal strength %)
+* Included AP Mapping tab in UI for adding friendly AP names to survey points.
+
+---
+
 ## Version 0.4.0 - 2026-01-07
 
 ### Changed

--- a/docs/Theory_of_Operation.md
+++ b/docs/Theory_of_Operation.md
@@ -34,9 +34,9 @@ to make the measurements of Wi-Fi strength and throughput.
 
 | Platform | Commands          | Notes |
 | -------- | ----------------- | ----- |
-| macOS    | `wdutil`, `ioreg`, `system_profiler` | sudo password required for `wdutil` |
-| Windows  | `netsh`           | Part of the system  |
 | Linux    | `nmcli`, `iw`     | `iw` or `nmcli` might need to be installed. |
+| macOS    | `wdutil`, `ioreg`, `system_profiler` | sudo password required for `wdutil` |
+| Windows  | N/A          | Uses Win32 WlanAPI  |
 | All | `iperf3` | See **iperf3** note below |
 
 **iperf3** must be installed locally to make TCP or UDP measurements.
@@ -87,13 +87,15 @@ to control logging, where the `level` is
 0: silly, 1: trace, 2: debug, 3: info, 4: warn, 5: error, 6: fatal.
 Use this when submitting the bug reports.
 
-On **Windows**, use the `set...` command like this:
+On **Windows** with command prompt, use the `set...` command like this:
 
 ```sh
 set LOG_LEVEL=level
 # echo %LOG_LEVEL% # optionally display the LOG_LEVEL
 npm run dev
 ```
+
+Or in PowerShell use `env$LOG_LEVEL=level`
 
 ## Component Hierarchy
 
@@ -312,30 +314,7 @@ appropriate property.
 
 ### Creating a localization file for your System Language
 
-To create a localization file for your Windows system's language:
-
-* Duplicate one of the _data/localization_ files
-* Rename it to _XX.json_, where "XX" is the proper code for the language
-  (e.g., _fr.json_ for a French system). The exact name is not important
-  except for the _.json_ suffix.
-* Run these four commands from the Windows command line:
-  * `netsh wlan show interfaces`
-  * `netsh wlan show networks mode="bssid"`
-  * `netsh wlan show profiles`
-  * `netsh wlan show profile name="profile"` where
-    `profile` is one of the profiles listed in the previous command
-* Paste the output of the all four commands into the bottom of the new file.
-* Comment out the new lines (use `//` at the start of the line),
-  and remove the prior output
-* Add a comment (use "//") indicating the version of Windows (Win10, Win11)
-  and the system language
-* In the JSON structure at the top of the file,
-  replace the localized phrases from the `netsh wlan...` output
-  (on the left) with the corresponding phrase on the right.
-* Restart the `wifi-heatmapper` server (`npm run dev`)
-  to read the new localized values
-* If you have a new file, or if you have questions, create an
-  [issue in the repo](https://github.com/hnykda/wifi-heatmapper/issues).
+Versions 0.5.0 and on do not require localization / localStorage.
 
 ## WebGL Heatmap Rendering
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,7 @@
 // const nextConfig = {};
 
 const nextConfig = {
+  serverExternalPackages: ["koffi"],
   eslint: {
     // Warning: This allows production builds to successfully complete even if
     // your project has ESLint errors.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,7 +8,6 @@
 @tailwind components;
 @tailwind utilities;
 
-
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/src/app/webGL/renderers/layers/heatmapLayerRenderer.ts
+++ b/src/app/webGL/renderers/layers/heatmapLayerRenderer.ts
@@ -8,7 +8,7 @@ import {
   getUniformLocations,
 } from "../../utils/webGLUtils";
 import { fullscreenQuadVertexShaderFlipY } from "@/app/webGL/shaders/fullscreenQuadVertexShader";
-import _ from "lodash";
+//import _ from "lodash";
 import { createGradientLUTTexture } from "../textures/createGradientLUTTexture";
 
 export const createHeatmapLayerRenderer = (
@@ -26,7 +26,7 @@ export const createHeatmapLayerRenderer = (
   const uniforms = getUniformLocations(gl, program);
 
   const colorLUT = createGradientLUTTexture(gl, gradient);
-  const maxSignal = _.maxBy(points, "value")?.value ?? 0;
+  //const maxSignal = _.maxBy(points, "value")?.value ?? 0;
   const flatData = Float32Array.from(
     points.flatMap(({ x, y, value }) => [x, y, value]),
   );
@@ -37,10 +37,20 @@ export const createHeatmapLayerRenderer = (
     influenceRadius: number;
     minOpacity: number;
     maxOpacity: number;
+    minSignal: number;
+    maxSignal: number;
   }) => {
     if (!points.length) return;
 
-    const { width, height, influenceRadius, minOpacity, maxOpacity } = options;
+    const {
+      width,
+      height,
+      influenceRadius,
+      minOpacity,
+      maxOpacity,
+      minSignal,
+      maxSignal,
+    } = options;
 
     gl.useProgram(program);
     gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
@@ -51,6 +61,7 @@ export const createHeatmapLayerRenderer = (
     gl.uniform1f(uniforms.u_power, 3);
     gl.uniform1f(uniforms.u_minOpacity, minOpacity);
     gl.uniform1f(uniforms.u_maxOpacity, maxOpacity);
+    gl.uniform1f(uniforms.u_minSignal, minSignal);
     gl.uniform1f(uniforms.u_maxSignal, maxSignal);
     gl.uniform2f(uniforms.u_resolution, width, height);
     gl.uniform1i(uniforms.u_pointCount, Math.min(points.length, points.length));

--- a/src/app/webGL/renderers/mainRenderer.ts
+++ b/src/app/webGL/renderers/mainRenderer.ts
@@ -29,6 +29,8 @@ const mainRenderer = (
     backgroundImageSrc?: string;
     minOpacity?: number;
     maxOpacity?: number;
+    minSignal: number;
+    maxSignal: number;
     influenceRadius?: number;
   }) => {
     const {
@@ -37,6 +39,8 @@ const mainRenderer = (
       minOpacity = 0.2,
       maxOpacity = 0.7,
       influenceRadius = 100,
+      minSignal,
+      maxSignal,
       backgroundImageSrc,
     } = props;
 
@@ -55,6 +59,8 @@ const mainRenderer = (
       influenceRadius,
       minOpacity,
       maxOpacity,
+      minSignal,
+      maxSignal,
     });
   };
 

--- a/src/app/webGL/shaders/heatmapFragmentShader.ts
+++ b/src/app/webGL/shaders/heatmapFragmentShader.ts
@@ -15,6 +15,7 @@ const generateHeatmapFragmentShader = (pointCount: number): string => {
 
   uniform float u_radius;       // Radius of influence for each point
   uniform float u_power;        // Weight falloff exponent (higher = faster decay)
+  uniform float u_minSignal; // Minimum expected signal value (used for normalization)
   uniform float u_maxSignal;    // Maximum expected signal value (used for normalization)
   uniform float u_opacity;      // Final fragment opacity
   uniform float u_minOpacity;   // opacity when signal = 0
@@ -66,7 +67,8 @@ const generateHeatmapFragmentShader = (pointCount: number): string => {
     // Normalize signal to [0, 1] range
     // Example: if weightedSum = 3, weightTotal = 5 → signal = 0.6
     float signal = weightedSum / weightTotal;
-    float normalized = clamp(signal / u_maxSignal, 0.0, 1.0);
+    // Example: signal = -70, u_minSignal = -100, u_maxSignal = -40 → (−70−(−100)) / (−40−(−100)) = 30/60 = 0.5
+    float normalized = clamp((signal - u_minSignal) / (u_maxSignal - u_minSignal), 0.0, 1.0);
 
     // Lookup color from LUT texture using normalized signal
     // Example: normalized = 0.75 → texture2D(u_lut, vec2(0.75, 0.5))

--- a/src/app/webGL/utils/webGLUtils.ts
+++ b/src/app/webGL/utils/webGLUtils.ts
@@ -22,6 +22,7 @@ export const getUniformLocations = (
   u_power: gl.getUniformLocation(program, "u_power"),
   u_minOpacity: gl.getUniformLocation(program, "u_minOpacity"),
   u_maxOpacity: gl.getUniformLocation(program, "u_maxOpacity"),
+  u_minSignal: gl.getUniformLocation(program, "u_minSignal"),
   u_maxSignal: gl.getUniformLocation(program, "u_maxSignal"),
   u_resolution: gl.getUniformLocation(program, "u_resolution"),
   u_pointCount: gl.getUniformLocation(program, "u_pointCount"),

--- a/src/components/Floorplan.tsx
+++ b/src/components/Floorplan.tsx
@@ -73,7 +73,7 @@ export default function ClickableFloorplan(): ReactNode {
         console.log(`image error`);
       };
     }
-  }, []);
+  }, [settings.floorplanImagePath]);
 
   /**
    * addTestPoint() - add a test point

--- a/src/components/Floorplan.tsx
+++ b/src/components/Floorplan.tsx
@@ -14,6 +14,7 @@ import NewToast from "@/components/NewToast";
 import PopupDetails from "@/components/PopupDetails";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { getLogger } from "../lib/logger";
+import { Switch } from "@/components/ui/switch";
 const logger = getLogger("Floorplan");
 
 export default function ClickableFloorplan(): ReactNode {
@@ -30,6 +31,8 @@ export default function ClickableFloorplan(): ReactNode {
   const [alertMessage, setAlertMessage] = useState("");
   const [isToastOpen, setIsToastOpen] = useState(false);
   const [surveyClick, setSurveyClick] = useState({ x: 0, y: 0 });
+  const [showSignalStrengthAsPercentage, setShowSignalStrengthAsPercentage] =
+    useState(false); // default to RSSI
 
   /**
    * Adding test points
@@ -110,7 +113,12 @@ export default function ClickableFloorplan(): ReactNode {
       canvas.style.height = "auto";
       drawCanvas();
     }
-  }, [imageLoaded, settings.dimensions, settings.surveyPoints]);
+  }, [
+    imageLoaded,
+    settings.dimensions,
+    settings.surveyPoints,
+    showSignalStrengthAsPercentage,
+  ]);
 
   const handleToastIsReady = (): void => {
     measureSurveyPoint(surveyClick);
@@ -242,7 +250,7 @@ export default function ClickableFloorplan(): ReactNode {
         // draw the image "behind" everything else
         ctx.drawImage(imageRef.current, 0, 0);
         // draw the points on top
-        drawPoints(settings.surveyPoints, ctx);
+        drawPoints(settings.surveyPoints, ctx, showSignalStrengthAsPercentage);
       }
     }
   };
@@ -258,9 +266,20 @@ export default function ClickableFloorplan(): ReactNode {
    * @param ctx
    * @param points
    */
-  const drawPoints = (points: SurveyPoint[], ctx: CanvasRenderingContext2D) => {
+  const drawPoints = (
+    points: SurveyPoint[],
+    ctx: CanvasRenderingContext2D,
+    showSignalStrengthAsPercentage: boolean,
+  ) => {
     const canvas = canvasRef.current;
-    points.forEach((point) => drawPoint(point, ctx, { bgW: canvas!.width }));
+    points.forEach((point) =>
+      drawPoint(
+        point,
+        ctx,
+        { bgW: canvas!.width },
+        showSignalStrengthAsPercentage,
+      ),
+    );
   };
 
   type ScaleOpts = {
@@ -273,6 +292,7 @@ export default function ClickableFloorplan(): ReactNode {
     point: SurveyPoint,
     ctx: CanvasRenderingContext2D,
     opts: ScaleOpts,
+    showSignalStrengthAsPercentage: boolean,
   ) {
     if (!point.wifiData) return;
 
@@ -289,14 +309,15 @@ export default function ClickableFloorplan(): ReactNode {
     const SHADOW_OFF = 0.002 * bgW;
 
     const wifiInfo = point.wifiData;
+    const colorValue = showSignalStrengthAsPercentage
+      ? (wifiInfo.signalStrength || 0) / 100
+      : rssiToPercentage(wifiInfo.rssi) / 100;
 
     // Main point
     ctx.beginPath();
     ctx.arc(point.x, point.y, R, 0, 2 * Math.PI);
     ctx.fillStyle = point.isEnabled
-      ? objectToRGBAString(
-          getColorAt(rssiToPercentage(wifiInfo.rssi) / 100, settings.gradient),
-        )
+      ? objectToRGBAString(getColorAt(colorValue, settings.gradient))
       : "rgba(156, 163, 175, 0.9)";
     ctx.fill();
 
@@ -307,7 +328,9 @@ export default function ClickableFloorplan(): ReactNode {
     ctx.stroke();
 
     // Annotation
-    const annotation = `${wifiInfo.signalStrength}%`;
+    const annotation = showSignalStrengthAsPercentage
+      ? `${wifiInfo.signalStrength}%`
+      : `${wifiInfo.rssi}dBm`;
     ctx.font = `${FONT}px Arial`;
     const lines = annotation.split("\n");
     const boxWidth =
@@ -443,6 +466,16 @@ export default function ClickableFloorplan(): ReactNode {
             <div>Total Measurements: {settings.surveyPoints.length}</div>
           )}
         </div>
+      </div>
+      <div className="mb-4 flex items-center space-x-2">
+        <Switch
+          id="floorplan-signal-strength-percentage"
+          checked={showSignalStrengthAsPercentage}
+          onCheckedChange={setShowSignalStrengthAsPercentage}
+        />
+        <label htmlFor="floorplan-signal-strength-percentage">
+          Show Signal Strength as Percentage
+        </label>
       </div>
       {alertMessage != "" && (
         <Alert variant="destructive">

--- a/src/components/Heatmaps.tsx
+++ b/src/components/Heatmaps.tsx
@@ -85,7 +85,7 @@ export function Heatmaps() {
   >(["bitsPerSecond"]);
 
   const [showSignalStrengthAsPercentage, setShowSignalStrengthAsPercentage] =
-    useState(true);
+    useState(false);
 
   // const r1 = calculateRadiusByDensity; // bad for small numbers of points
   const r2 = calculateRadiusByBoundingBox;
@@ -151,7 +151,7 @@ export function Heatmaps() {
       const data = points
         .filter((p) => p.isEnabled)
         .map((point) => {
-          let value = getMetricValue(point, metric, testType);
+          const value = getMetricValue(point, metric, testType);
           switch (metric) {
             case "tcpDownload":
             case "tcpUpload":
@@ -160,8 +160,8 @@ export function Heatmaps() {
               if (value == 0) return null;
               break;
             case "signalStrength":
-              // always map the 0-100% signal strength (not rssi)
-              value = point.wifiData.signalStrength;
+            // always map the 0-100% signal strength (not rssi)
+            //value = point.wifiData.signalStrength;
           }
           return value !== null ? { x: point.x, y: point.y, value } : null;
         })
@@ -355,6 +355,8 @@ export function Heatmaps() {
           backgroundImageSrc: settings.floorplanImagePath,
           width: settings.dimensions.width,
           height: settings.dimensions.height,
+          minSignal: min,
+          maxSignal: max,
         });
 
         ctx.drawImage(glCanvas, 0, 20);

--- a/src/components/PointsTable.tsx
+++ b/src/components/PointsTable.tsx
@@ -83,7 +83,7 @@ const SurveyPointsTable: React.FC<SurveyPointsTableProps> = ({
     tcpUploadMbps: true,
     timestamp: true,
     disable: true,
-    rssi: false,
+    rssi: true,
     ssid: false,
     security: false,
     txRate: false,
@@ -223,13 +223,15 @@ const SurveyPointsTable: React.FC<SurveyPointsTableProps> = ({
 
   const flattenedData: FlattenedSurveyPoint[] = useMemo(() => {
     return data.map((point) => {
-      let bssid = point.wifiData.bssid;
+      let bssid =
+        point.wifiData.bssid.match(/.{1,2}/g)?.join(":") ||
+        point.wifiData.bssid;
       if (apMapping.length > 0) {
         const mappedName = apMapping.find(
           (ap) => ap.macAddress === point.wifiData.bssid,
         )?.apName;
         if (mappedName) {
-          bssid = `${mappedName} (${point.wifiData.bssid})`;
+          bssid = `${mappedName} (${bssid})`;
         }
       }
       return {

--- a/src/components/TabPanel.tsx
+++ b/src/components/TabPanel.tsx
@@ -6,10 +6,11 @@ import SettingsEditor from "@/components/SettingsEditor";
 import ClickableFloorplan from "@/components/Floorplan";
 import { Heatmaps } from "@/components/Heatmaps";
 import PointsTable from "@/components/PointsTable";
+import EditableApMapping from "@/components/ApMapping";
 
 export default function TabPanel() {
   const [activeTab, setActiveTab] = useState("tab1"); // State to track the active tab
-  const { settings, surveyPointActions } = useSettings();
+  const { settings, surveyPointActions, updateSettings } = useSettings();
 
   return (
     <div className="w-full p-2">
@@ -45,6 +46,13 @@ export default function TabPanel() {
           >
             Survey&nbsp;Points
           </Tabs.Trigger>
+          <Tabs.Trigger
+            value="tab5"
+            data-radix-collection-item
+            className="px-4 py-2.5 text-base font-medium bg-gray-300 text-gray-800 border border-gray-400 border-b-0 rounded-t-md cursor-pointer transition-all duration-300 ease-in-out hover:bg-gray-200 data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:font-semibold data-[state=active]:border-gray-500"
+          >
+            AP&nbsp;Mapping
+          </Tabs.Trigger>
         </Tabs.List>
 
         {/* Tab Content */}
@@ -65,6 +73,15 @@ export default function TabPanel() {
             data={settings.surveyPoints}
             surveyPointActions={surveyPointActions}
             apMapping={settings.apMapping}
+          />
+        </Tabs.Content>
+
+        <Tabs.Content value="tab5" className="p-4">
+          <EditableApMapping
+            apMapping={settings.apMapping || []}
+            onSave={(newMapping) => {
+              updateSettings({ ...settings, apMapping: newMapping });
+            }}
           />
         </Tabs.Content>
       </Tabs.Root>

--- a/src/lib/iperfRunner.ts
+++ b/src/lib/iperfRunner.ts
@@ -9,7 +9,7 @@ import {
 // import { scanWifi, blinkWifi } from "./wifiScanner";
 import { execAsync, delay } from "./server-utils";
 import { getCancelFlag, sendSSEMessage } from "./server-globals";
-import { percentageToRssi, toMbps, getDefaultIperfResults } from "./utils";
+import { toMbps, getDefaultIperfResults } from "./utils";
 import { SSEMessageType } from "@/app/api/events/route";
 import { createWifiActions } from "./wifiScanner";
 import { getLogger } from "./logger";
@@ -152,6 +152,7 @@ export async function runSurveyTests(
         const server = settings.iperfServerAdrs;
         const duration = settings.testDuration;
         const wifiStrengths: number[] = []; // percentages
+        const wifiRssiValues: number[] = [];
         // add the SSID to the header if it's not <redacted>
         let newHeader = "Measuring Wi-Fi";
         if (!ssidName.includes("redacted")) {
@@ -165,6 +166,7 @@ export async function runSurveyTests(
           `Elapsed time for scan and switch: ${Date.now() - startTime}`,
         );
         wifiStrengths.push(wifiDataBefore.SSIDs[0].signalStrength);
+        wifiRssiValues.push(wifiDataBefore.SSIDs[0].rssi);
         displayStates.strength = arrayAverage(wifiStrengths).toString();
         checkForCancel();
         sendSSEMessage(getUpdatedMessage());
@@ -194,9 +196,13 @@ export async function runSurveyTests(
         checkForCancel();
         sendSSEMessage(getUpdatedMessage());
 
-        const wifiDataMiddle = await wifiActions.getWifi(settings);
-        wifiStrengths.push(wifiDataMiddle.SSIDs[0].signalStrength);
-        displayStates.strength = arrayAverage(wifiStrengths).toString();
+        let wifiDataMiddle = wifiDataBefore; // reuse if no tests are running
+        if (performIperfTest) {
+          wifiDataMiddle = await wifiActions.getWifi(settings);
+          wifiStrengths.push(wifiDataMiddle.SSIDs[0].signalStrength);
+          wifiRssiValues.push(wifiDataMiddle.SSIDs[0].rssi);
+          displayStates.strength = arrayAverage(wifiStrengths).toString();
+        }
         checkForCancel();
         sendSSEMessage(getUpdatedMessage());
 
@@ -224,9 +230,13 @@ export async function runSurveyTests(
         checkForCancel();
         sendSSEMessage(getUpdatedMessage());
 
-        const wifiDataAfter = await wifiActions.getWifi(settings);
-        wifiStrengths.push(wifiDataAfter.SSIDs[0].signalStrength);
-        displayStates.strength = arrayAverage(wifiStrengths).toString();
+        let wifiDataAfter = wifiDataBefore; // reuse if no tests are running
+        if (performIperfTest) {
+          wifiDataAfter = await wifiActions.getWifi(settings);
+          wifiStrengths.push(wifiDataAfter.SSIDs[0].signalStrength);
+          wifiRssiValues.push(wifiDataMiddle.SSIDs[0].rssi);
+          displayStates.strength = arrayAverage(wifiStrengths).toString();
+        }
         checkForCancel();
 
         // Send the final update - type is "done"
@@ -249,7 +259,7 @@ export async function runSurveyTests(
         newWifiData = {
           ...wifiDataBefore.SSIDs[0],
           signalStrength: strength, // use the average signalStrength
-          rssi: percentageToRssi(strength), // set corresponding RSSI
+          rssi: arrayAverage(wifiRssiValues), // average of real per-sample RSSI, replacing percentageToRssi(strength)
         };
       } catch (error: any) {
         logger.error(`Attempt ${attempts} failed:`, error);

--- a/src/lib/wifiScanner-windows.ts
+++ b/src/lib/wifiScanner-windows.ts
@@ -109,7 +109,7 @@ export class WindowsWifiActions implements WifiActions {
           // Fill in channel/band from scan (not available in connection attributes)
           current.channel = match.channel;
           current.band = match.band;
-          console.log(
+          console.debug(
             `DEBUG: rssi approximation was ${current.rssi}, real BSS value is ${match.rssi}`,
           );
           current.rssi = match.rssi; // Real dBm value from the BSS scan, replacing the quality-based approximation
@@ -164,7 +164,7 @@ export class WindowsWifiActions implements WifiActions {
           if (match) {
             current.channel = match.channel;
             current.band = match.band;
-            console.log(
+            console.debug(
               `DEBUG: rssi approximation was ${current.rssi}, real BSS value is ${match.rssi}`,
             );
             current.rssi = match.rssi; // Real dBm value from the BSS scan

--- a/src/lib/wifiScanner-windows.ts
+++ b/src/lib/wifiScanner-windows.ts
@@ -109,13 +109,17 @@ export class WindowsWifiActions implements WifiActions {
           // Fill in channel/band from scan (not available in connection attributes)
           current.channel = match.channel;
           current.band = match.band;
+          console.log(
+            `DEBUG: rssi approximation was ${current.rssi}, real BSS value is ${match.rssi}`,
+          );
+          current.rssi = match.rssi; // Real dBm value from the BSS scan, replacing the quality-based approximation
         }
         this.currentSSIDName = current.ssid;
       }
 
       response.SSIDs = networks;
     } catch (err) {
-      response.reason = `Cannot get wifi info: ${err}`;
+      response.reason = `Cannot get wifi info from scanWifi: ${err}`;
     }
 
     return response;
@@ -160,6 +164,10 @@ export class WindowsWifiActions implements WifiActions {
           if (match) {
             current.channel = match.channel;
             current.band = match.band;
+            console.log(
+              `DEBUG: rssi approximation was ${current.rssi}, real BSS value is ${match.rssi}`,
+            );
+            current.rssi = match.rssi; // Real dBm value from the BSS scan
           }
         } catch {
           // Scan failed, proceed without channel info

--- a/src/lib/wifiScanner-windows.ts
+++ b/src/lib/wifiScanner-windows.ts
@@ -109,9 +109,6 @@ export class WindowsWifiActions implements WifiActions {
           // Fill in channel/band from scan (not available in connection attributes)
           current.channel = match.channel;
           current.band = match.band;
-          console.debug(
-            `DEBUG: rssi approximation was ${current.rssi}, real BSS value is ${match.rssi}`,
-          );
           current.rssi = match.rssi; // Real dBm value from the BSS scan, replacing the quality-based approximation
         }
         this.currentSSIDName = current.ssid;
@@ -164,9 +161,6 @@ export class WindowsWifiActions implements WifiActions {
           if (match) {
             current.channel = match.channel;
             current.band = match.band;
-            console.debug(
-              `DEBUG: rssi approximation was ${current.rssi}, real BSS value is ${match.rssi}`,
-            );
             current.rssi = match.rssi; // Real dBm value from the BSS scan
           }
         } catch {

--- a/src/lib/wlan-api.ts
+++ b/src/lib/wlan-api.ts
@@ -41,8 +41,8 @@ type KoffiModule = {
   out: (type: unknown) => unknown;
   decode: (
     buffer: unknown,
-    type: unknown,
-    offset?: number,
+    offsetOrType: unknown,
+    type?: unknown,
   ) => Record<string, unknown>;
 };
 
@@ -53,9 +53,11 @@ let wlanapi: KoffiLib | null = null;
 let GUID: unknown;
 let DOT11_SSID: unknown;
 let WLAN_INTERFACE_INFO: unknown;
-let WLAN_INTERFACE_INFO_LIST: unknown;
+//let WLAN_INTERFACE_INFO_LIST: unknown;
 let WLAN_BSS_ENTRY: unknown;
-let WLAN_BSS_LIST: unknown;
+//let WLAN_BSS_LIST: unknown;
+let WLAN_INTERFACE_INFO_LIST_HEADER: unknown;
+let WLAN_BSS_LIST_HEADER: unknown;
 let WLAN_ASSOCIATION_ATTRIBUTES: unknown;
 let WLAN_SECURITY_ATTRIBUTES: unknown;
 let WLAN_CONNECTION_ATTRIBUTES: unknown;
@@ -68,6 +70,7 @@ let WlanEnumInterfaces: ((...args: unknown[]) => number) | null = null;
 let WlanGetNetworkBssList: ((...args: unknown[]) => number) | null = null;
 let WlanQueryInterface: ((...args: unknown[]) => number) | null = null;
 let WlanFreeMemory: ((...args: unknown[]) => void) | null = null;
+let WlanScan: ((...args: unknown[]) => number) | null = null;
 
 // Error codes
 const ERROR_SUCCESS = 0;
@@ -109,7 +112,7 @@ const AUTH_ALGORITHM_MAP: Record<number, string> = {
   5: "WPA-None", // DOT11_AUTH_ALGO_WPA_NONE
   6: "WPA2", // DOT11_AUTH_ALGO_RSNA
   7: "WPA2-Personal", // DOT11_AUTH_ALGO_RSNA_PSK
-  8: "WPA3", // DOT11_AUTH_ALGO_WPA3
+  8: "WPA3-Enterprise (192-bit)", // DOT11_AUTH_ALGO_WPA3_ENT_192
   9: "WPA3-Personal", // DOT11_AUTH_ALGO_WPA3_SAE
   10: "OWE", // DOT11_AUTH_ALGO_OWE
   11: "WPA3-Enterprise", // DOT11_AUTH_ALGO_WPA3_ENT
@@ -131,7 +134,6 @@ async function initialize(): Promise<boolean> {
   try {
     // Dynamic import koffi only on Windows
     // This will fail on non-Windows platforms since koffi has no prebuilt binary
-
     const koffiModule = await import(/* webpackIgnore: true */ "koffi");
     koffi = koffiModule.default as unknown as KoffiModule;
 
@@ -155,13 +157,13 @@ async function initialize(): Promise<boolean> {
       strInterfaceDescription: koffi.array("uint16", 256), // WCHAR[256]
       isState: "int32",
     });
-
+    /*
     WLAN_INTERFACE_INFO_LIST = koffi.struct("WLAN_INTERFACE_INFO_LIST", {
       dwNumberOfItems: "uint32",
       dwIndex: "uint32",
       InterfaceInfo: koffi.array(WLAN_INTERFACE_INFO, 1), // Variable length
     });
-
+    */
     WLAN_RATE_SET = koffi.struct("WLAN_RATE_SET", {
       uRateSetLength: "uint32",
       usRateSet: koffi.array("uint16", 126),
@@ -185,12 +187,25 @@ async function initialize(): Promise<boolean> {
       ulIeOffset: "uint32",
       ulIeSize: "uint32",
     });
-
+    /*
     WLAN_BSS_LIST = koffi.struct("WLAN_BSS_LIST", {
       dwTotalSize: "uint32",
       dwNumberOfItems: "uint32",
       wlanBssEntries: koffi.array(WLAN_BSS_ENTRY, 1), // Variable length
     });
+    */
+    WLAN_BSS_LIST_HEADER = koffi.struct("WLAN_BSS_LIST_HEADER", {
+      dwTotalSize: "uint32",
+      dwNumberOfItems: "uint32",
+    });
+
+    WLAN_INTERFACE_INFO_LIST_HEADER = koffi.struct(
+      "WLAN_INTERFACE_INFO_LIST_HEADER",
+      {
+        dwNumberOfItems: "uint32",
+        dwIndex: "uint32",
+      },
+    );
 
     WLAN_ASSOCIATION_ATTRIBUTES = koffi.struct("WLAN_ASSOCIATION_ATTRIBUTES", {
       dot11Ssid: DOT11_SSID,
@@ -225,7 +240,7 @@ async function initialize(): Promise<boolean> {
       "uint32",
       "void*",
       koffiAny.out(koffiAny.pointer("uint32")),
-      "void**",
+      koffiAny.out(koffiAny.pointer("void*")),
     ]) as (...args: unknown[]) => number;
 
     WlanCloseHandle = wlanapi.func("__stdcall", "WlanCloseHandle", "uint32", [
@@ -233,11 +248,23 @@ async function initialize(): Promise<boolean> {
       "void*",
     ]) as (...args: unknown[]) => number;
 
+    WlanScan = wlanapi.func("__stdcall", "WlanScan", "uint32", [
+      "void*", // hClientHandle
+      koffiAny.pointer(GUID), // pInterfaceGuid
+      "void*", // pDot11Ssid (NULL = scan all)
+      "void*", // pIeData (NULL)
+      "void*", // pReserved
+    ]) as (...args: unknown[]) => number;
+
     WlanEnumInterfaces = wlanapi.func(
       "__stdcall",
       "WlanEnumInterfaces",
       "uint32",
-      ["void*", "void*", "void**"],
+      [
+        "void*",
+        "void*",
+        koffiAny.out(koffiAny.pointer("void*")), // ppInterfaceList
+      ],
     ) as (...args: unknown[]) => number;
 
     WlanGetNetworkBssList = wlanapi.func(
@@ -251,7 +278,7 @@ async function initialize(): Promise<boolean> {
         "int32", // dot11BssType
         "uint8", // bSecurityEnabled
         "void*", // pReserved
-        "void**", // ppWlanBssList
+        koffiAny.out(koffiAny.pointer("void*")), // ppWlanBssList
       ],
     ) as (...args: unknown[]) => number;
 
@@ -265,7 +292,7 @@ async function initialize(): Promise<boolean> {
         "int32", // OpCode
         "void*", // pReserved
         koffiAny.out(koffiAny.pointer("uint32")), // pdwDataSize
-        "void**", // ppData
+        koffiAny.out(koffiAny.pointer("void*")), // ppData
         "void*", // pWlanOpcodeValueType
       ],
     ) as (...args: unknown[]) => number;
@@ -309,8 +336,10 @@ function frequencyToChannel(freqKHz: number): number {
 /**
  * Convert 6-byte MAC address to normalized string (lowercase, no separators)
  */
-function macBytesToString(bytes: number[]): string {
-  return bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+function macBytesToString(bytes: number[] | Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 /**
@@ -332,6 +361,30 @@ function wcharToString(wchars: number[]): string {
 }
 
 /**
+ * Decode a Win32 struct with a variable-length trailing array
+ * (the classic "struct { count; T items[1]; }" pattern).
+ */
+function decodeVariableLengthArray<T = Record<string, unknown>>(
+  buffer: unknown,
+  headerType: unknown,
+  countFieldName: string,
+  elementType: unknown,
+): T[] {
+  const header = koffi!.decode(buffer, headerType) as Record<string, unknown>;
+  const count = header[countFieldName] as number;
+
+  const headerSize = (koffi as any).sizeof(headerType);
+  const elementSize = (koffi as any).sizeof(elementType);
+
+  const items: T[] = [];
+  for (let i = 0; i < count; i++) {
+    const offset = headerSize + i * elementSize;
+    items.push(koffi!.decode(buffer, offset, elementType) as T);
+  }
+  return items;
+}
+
+/**
  * Open a handle to the WLAN API
  */
 async function openHandle(): Promise<{
@@ -344,6 +397,7 @@ async function openHandle(): Promise<{
   const handleOut = [null];
 
   const result = WlanOpenHandle(2, null, versionOut, handleOut);
+
   if (result !== ERROR_SUCCESS) {
     return null;
   }
@@ -358,7 +412,9 @@ async function getFirstInterface(): Promise<{
   guid: unknown;
   description: string;
 } | null> {
-  if (!koffi) return null;
+  if (!(await initialize()) || !koffi) {
+    throw new Error("Failed to initialize WLAN API");
+  }
 
   const session = await openHandle();
   if (!session) return null;
@@ -371,17 +427,16 @@ async function getFirstInterface(): Promise<{
     }
 
     try {
-      const list = koffi.decode(listOut[0], WLAN_INTERFACE_INFO_LIST) as Record<
-        string,
-        unknown
-      >;
-      const count = list.dwNumberOfItems as number;
-      if (count === 0) return null;
+      const interfaces = decodeVariableLengthArray(
+        listOut[0],
+        WLAN_INTERFACE_INFO_LIST_HEADER,
+        "dwNumberOfItems",
+        WLAN_INTERFACE_INFO,
+      ) as Record<string, unknown>[];
 
-      // Get first interface
-      const interfaces = list.InterfaceInfo as Record<string, unknown>[];
+      if (interfaces.length === 0) return null;
+
       const firstIface = interfaces[0];
-
       return {
         guid: firstIface.InterfaceGuid,
         description: wcharToString(
@@ -397,6 +452,55 @@ async function getFirstInterface(): Promise<{
 }
 
 /**
+ * Poll WlanGetNetworkBssList until it returns a non-empty result or
+ * the timeout is reached. Not a substitute for a real scan-complete
+ * signal (WlanRegisterNotification) — see caveats below.
+ */
+async function waitForBssResults(
+  handle: unknown,
+  guid: unknown,
+  { intervalMs = 100, timeoutMs = 5000 } = {},
+): Promise<unknown> {
+  const deadline = Date.now() + timeoutMs;
+  let lastListOut: unknown[] = [null];
+
+  while (Date.now() < deadline) {
+    const listOut = [null];
+    const result = WlanGetNetworkBssList!(
+      handle,
+      guid,
+      null,
+      DOT11_BSS_TYPE.dot11_BSS_type_any,
+      0,
+      null,
+      listOut,
+    );
+
+    if (result === ERROR_SUCCESS && listOut[0]) {
+      const header = koffi!.decode(listOut[0], WLAN_BSS_LIST_HEADER) as Record<
+        string,
+        unknown
+      >;
+      const count = header.dwNumberOfItems as number;
+
+      if (count > 0) {
+        return listOut[0]; // Ready — hand back the raw buffer
+      }
+
+      // Empty this round — free it, we'll ask again
+      WlanFreeMemory!(listOut[0]);
+    }
+
+    lastListOut = listOut;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  // Timed out — return whatever the last attempt gave us (may be null
+  // or an empty-but-valid buffer; caller decides what to do with that).
+  return lastListOut[0];
+}
+
+/**
  * Scan for available WiFi networks
  * @returns Array of WifiResults sorted by signal strength
  */
@@ -405,7 +509,7 @@ export async function scanNetworks(): Promise<WifiResults[]> {
     throw new Error("WLAN API is only available on Windows");
   }
 
-  if (!koffi || !(await initialize())) {
+  if (!(await initialize()) || !koffi) {
     throw new Error("Failed to initialize WLAN API");
   }
 
@@ -416,38 +520,34 @@ export async function scanNetworks(): Promise<WifiResults[]> {
 
   try {
     const iface = await getFirstInterface();
+
     if (!iface) {
+      console.error(`No wireless interface found`);
       throw new Error("No wireless interface found");
     }
 
-    const listOut = [null];
-    const result = WlanGetNetworkBssList!(
-      session.handle,
-      iface.guid,
-      null, // All SSIDs
-      DOT11_BSS_TYPE.dot11_BSS_type_any,
-      0, // Don't filter by security
-      null,
-      listOut,
-    );
+    const scanResult = WlanScan!(session.handle, iface.guid, null, null, null);
+    if (scanResult !== ERROR_SUCCESS) {
+      console.error(
+        `WlanScan failed with error ${scanResult}, using cached results`,
+      );
+    }
 
-    if (result !== ERROR_SUCCESS || !listOut[0]) {
-      throw new Error(`WlanGetNetworkBssList failed with error ${result}`);
+    const bssBuffer = await waitForBssResults(session.handle, iface.guid);
+    if (!bssBuffer) {
+      throw new Error("WlanGetNetworkBssList returned no data");
     }
 
     try {
-      const bssList = koffi.decode(listOut[0], WLAN_BSS_LIST) as Record<
-        string,
-        unknown
-      >;
-      const count = bssList.dwNumberOfItems as number;
+      const entries = decodeVariableLengthArray(
+        bssBuffer,
+        WLAN_BSS_LIST_HEADER,
+        "dwNumberOfItems",
+        WLAN_BSS_ENTRY,
+      ) as Record<string, unknown>[];
       const results: WifiResults[] = [];
 
-      // Get the array of BSS entries
-      const entries = bssList.wlanBssEntries as Record<string, unknown>[];
-
-      for (let i = 0; i < count; i++) {
-        const entry = entries[i];
+      for (const entry of entries) {
         const ssidData = entry.dot11Ssid as Record<string, unknown>;
         const ssid = ssidBytesToString(
           ssidData.ucSSID as number[],
@@ -478,7 +578,7 @@ export async function scanNetworks(): Promise<WifiResults[]> {
 
       return results.sort(bySignalStrength);
     } finally {
-      WlanFreeMemory!(listOut[0]);
+      WlanFreeMemory!(bssBuffer);
     }
   } finally {
     WlanCloseHandle!(session.handle, null);
@@ -494,7 +594,7 @@ export async function getCurrentConnection(): Promise<WifiResults | null> {
     throw new Error("WLAN API is only available on Windows");
   }
 
-  if (!koffi || !(await initialize())) {
+  if (!(await initialize()) || !koffi) {
     throw new Error("Failed to initialize WLAN API");
   }
 
@@ -560,7 +660,6 @@ export async function getCurrentConnection(): Promise<WifiResults | null> {
       const txRateKbps = assocAttrs.ulTxRate as number;
       const phyType = assocAttrs.dot11PhyType as number;
       const authAlgo = secAttrs.dot11AuthAlgorithm as number;
-
       const wifi = getDefaultWifiResults();
       wifi.ssid = ssid;
       wifi.bssid = macBytesToString(assocAttrs.dot11Bssid as number[]);


### PR DESCRIPTION
### Summary of changes

## `src/lib/wlan-api.ts`
- Fixed short-circuit ordering bugs in `getFirstInterface()`, `scanNetworks()`, and `getCurrentConnection()` — `initialize()` wasn't being called on first run because `!koffi` short-circuited before it.
- Fixed `void**` out-parameters not wrapped in `koffi.out()` for `WlanOpenHandle`, `WlanEnumInterfaces`, `WlanGetNetworkBssList`, and `WlanQueryInterface`.
- Added `decodeVariableLengthArray()` helper plus header-only struct types (`WLAN_BSS_LIST_HEADER`, `WLAN_INTERFACE_INFO_LIST_HEADER`) to correctly decode variable-length trailing arrays, replacing the broken fixed-length-1 array declarations — also avoids an out-of-bounds read risk when a list is empty.
- Fixed the `koffi.decode()` argument order inside that helper — real signature is `(buffer, offset, type)`, not `(buffer, type, offset)`.
- Added `WlanScan` + a `waitForBssResults()` polling helper, called before reading the BSS list in `scanNetworks()`, so results reflect a fresh scan rather than a stale cache.
- Fixed the macBytesToString() helper function to use Array.from(bytes) before mapping. The typed array Uint8Array was causing the native JavaScript .map() method to force hexadecimal characters back into standard integers, truncating values like 88:9c:ad:27:6c:6f down to 88002700.
- _**To do:** missing `security` field for scanned (non-connected) networks would need `WlanGetAvailableNetworkList`; `dot11AuthAlgorithm` can't reliably distinguish WPA2-Enterprise from standard WPA3-Enterprise (but netsh wlan can)._

## `src/lib/wifiScanner-windows.ts`
- In both `scanWifi()` and `getWifi()`, added `current.rssi = match.rssi;` to the existing BSSID-match merge — replaces `getCurrentConnection()`'s quality-based RSSI approximation with the real dBm value from the BSS scan, the same way `channel`/`band` were already being backfilled.

## `src/lib/iperfRunner.ts`
- Added `wifiRssiValues` array, averaged via `arrayAverage()` the same way `wifiStrengths` already was, replacing `rssi: percentageToRssi(strength)` with a real-RSSI average.
- Gated the middle/after `wifiActions.getWifi()` calls behind `performIperfTest`, reusing `wifiDataBefore` when Iperf tests are skipped.
- Fixed resulting lint errors: removed now-unused `percentageToRssi` import, removed a variable-shadowing bug (`const` inside the `if` blocks was shadowing the outer `let`).

## `src/app/webGL/shaders/heatmapFragmentShader.ts`
- Added `u_minSignal` uniform and changed normalization from `signal / u_maxSignal` to `(signal - u_minSignal) / (u_maxSignal - u_minSignal)` — the original division-based formula inverted ordering for negative RSSI values, collapsing nearly the whole heatmap to one color.

## `src/app/webGL/renderers/layers/heatmapLayerRenderer.ts`
- Removed the internal `_.maxBy(points, "value")` derivation.
- Added `minSignal`/`maxSignal` as accepted parameters, passed through to the new `u_minSignal`/`u_maxSignal` uniforms.

## `src/app/webGL/renderers/mainRenderer.ts`
- Threaded `minSignal`/`maxSignal` through `render()`'s options into `heatmapRenderer.draw()`.

## `src/app/webGL/utils/webGLUtils.ts`
- Added `u_minSignal: gl.getUniformLocation(program, "u_minSignal")` to `getUniformLocations()`.

## `src/components/Heatmaps.tsx`
- Included the actual RSSI rather than estimated from percentageToRssi().

## `src/components/PointsTable.tsx`
- Reformatted the raw 12-character string into clean, readable colon pairs (e.g. 88:ab:cd:27:cd:ef) for the primary UI display grid.

## `src/components/Floorplan.tsx`
- Included a toggle to switch between RSSI and Signal Strength.

## `src/components/TabPanel.tsx`
- Included AP Mapping tab.
- _To do: Needs a bulk import function._

## `next.config.mjs`
- Added `serverExternalPackages: ["koffi"]` so Next.js doesn't try to bundle koffi's native `.node` addon.